### PR TITLE
Custom video controls and quality selector

### DIFF
--- a/src/lib/apis/jellyfin/jellyfinApi.ts
+++ b/src/lib/apis/jellyfin/jellyfinApi.ts
@@ -144,7 +144,8 @@ export const getJellyfinItem = async (itemId: string) =>
 export const getJellyfinPlaybackInfo = async (
 	itemId: string,
 	playbackProfile: DeviceProfile,
-	startTimeTicks = 0
+	startTimeTicks = 0,
+	maxStreamingBitrate = 140000000
 ) =>
 	getUserId().then((userId) =>
 		userId
@@ -157,7 +158,7 @@ export const getJellyfinPlaybackInfo = async (
 							userId,
 							startTimeTicks,
 							autoOpenLiveStream: true,
-							maxStreamingBitrate: 140000000
+							maxStreamingBitrate: maxStreamingBitrate
 						}
 					},
 					body: {
@@ -226,6 +227,18 @@ export const reportJellyfinPlaybackStopped = (
 			PlaySessionId: sessionId,
 			PositionTicks: Math.round(positionTicks),
 			MediaSourceId: itemId
+		}
+	});
+
+export const delteActiveEncoding = (
+	playSessionId: string
+) =>
+	JellyfinApi?.del('/Videos/ActiveEncodings', {
+		params: {
+			query: {
+				deviceId: JELLYFIN_DEVICE_ID,
+				playSessionId: playSessionId
+			}
 		}
 	});
 

--- a/src/lib/apis/jellyfin/qualities.ts
+++ b/src/lib/apis/jellyfin/qualities.ts
@@ -8,7 +8,7 @@
 export function getQualities(resolution : number) {
     // We add one to the minimum resolution since some movies
     // have a resolution of 1080p, but the format isn't 16:9,
-    // so the high is less than 1080, so we detect as 1080p
+    // so the height is less than 1080, so we detect as 1080p
     // anything higher than 720p, and so on for the other.
     let data = [
         {

--- a/src/lib/apis/jellyfin/qualities.ts
+++ b/src/lib/apis/jellyfin/qualities.ts
@@ -1,0 +1,60 @@
+/**
+ * Returns an array containing all the available
+ * qualities the user can select when playing a video
+ * 
+ * @param resolution The resolution of the video
+ * @returns An array containing all the available qualities
+ */
+export function getQualities(resolution : number) {
+    let data = [
+        {
+            name: "4K - 120 Mbps",
+            maxBitrate: 120000000,
+            minResolution: 2160
+        },
+        {
+            name: "4K - 80 Mbps",
+            maxBitrate: 80000000,
+            minResolution: 2160
+        },
+        {
+            name: "1080p - 40 Mbps",
+            maxBitrate: 40000000,
+            minResolution: 1080
+        },
+        {
+            name: "1080p - 10 Mbps",
+            maxBitrate: 10000000,
+            minResolution: 1080
+        },
+        {
+            name: "720p - 8 Mbps",
+            maxBitrate: 8000000,
+            minResolution: 720
+        },
+        {
+            name: "720p - 4 Mbps",
+            maxBitrate: 4000000,
+            minResolution: 720
+        },
+        {
+            name: "480p - 3 Mbps",
+            maxBitrate: 3000000,
+            minResolution: 480
+        },
+        {
+            name: "480p - 720 Kbps",
+            maxBitrate: 720000,
+            minResolution: 480
+        },
+        {
+            name: "360p - 420 Kbps",
+            maxBitrate: 420000,
+            minResolution: 360
+        }
+    ]
+
+    return data.filter((quality) => {
+        return quality.minResolution <= resolution
+    });
+}

--- a/src/lib/apis/jellyfin/qualities.ts
+++ b/src/lib/apis/jellyfin/qualities.ts
@@ -6,51 +6,55 @@
  * @returns An array containing all the available qualities
  */
 export function getQualities(resolution : number) {
+    // We add one to the minimum resolution since some movies
+    // have a resolution of 1080p, but the format isn't 16:9,
+    // so the high is less than 1080, so we detect as 1080p
+    // anything higher than 720p, and so on for the other.
     let data = [
         {
             name: "4K - 120 Mbps",
             maxBitrate: 120000000,
-            minResolution: 2160
+            minResolution: 1080 + 1
         },
         {
             name: "4K - 80 Mbps",
             maxBitrate: 80000000,
-            minResolution: 2160
+            minResolution: 1080 + 1
         },
         {
             name: "1080p - 40 Mbps",
             maxBitrate: 40000000,
-            minResolution: 1080
+            minResolution: 720 + 1
         },
         {
             name: "1080p - 10 Mbps",
             maxBitrate: 10000000,
-            minResolution: 1080
+            minResolution: 720 + 1
         },
         {
             name: "720p - 8 Mbps",
             maxBitrate: 8000000,
-            minResolution: 720
+            minResolution: 480 + 1
         },
         {
             name: "720p - 4 Mbps",
             maxBitrate: 4000000,
-            minResolution: 720
+            minResolution: 480 + 1
         },
         {
             name: "480p - 3 Mbps",
             maxBitrate: 3000000,
-            minResolution: 480
+            minResolution: 360 + 1
         },
         {
             name: "480p - 720 Kbps",
             maxBitrate: 720000,
-            minResolution: 480
+            minResolution: 360 + 1
         },
         {
             name: "360p - 420 Kbps",
             maxBitrate: 420000,
-            minResolution: 360
+            minResolution: 0
         }
     ]
 

--- a/src/lib/components/ContextMenu/ContextMenu.svelte
+++ b/src/lib/components/ContextMenu/ContextMenu.svelte
@@ -6,11 +6,13 @@
 	export let disabled = false;
 	export let position: 'absolute' | 'fixed' = 'fixed';
 	let anchored = position === 'absolute';
+	export let bottom = false;
 
 	export let id = Symbol();
 
 	let menu: HTMLDivElement;
 	let windowWidth: number;
+	let windowHeight: number;
 
 	let fixedPosition = { x: 0, y: 0 };
 
@@ -46,6 +48,7 @@
 	on:keydown={handleShortcuts}
 	on:click={handleClickOutside}
 	bind:innerWidth={windowWidth}
+	bind:innerHeight={windowHeight}
 />
 <svelte:head>
 	{#if $contextMenu === id}
@@ -58,6 +61,7 @@
 </svelte:head>
 <!-- <svelte:body bind:this={body} /> -->
 
+<!-- svelte-ignore a11y-click-events-have-key-events -->
 <!-- svelte-ignore a11y-no-static-element-interactions -->
 <div on:contextmenu|preventDefault={handleOpen} on:click={(e) => anchored && e.stopPropagation()}>
 	<slot />
@@ -70,10 +74,10 @@
 			style={position === 'fixed'
 				? `left: ${
 						fixedPosition.x - (fixedPosition.x > windowWidth / 2 ? menu?.clientWidth : 0)
-				  }px; top: ${fixedPosition.y}px;`
+				  }px; top: ${fixedPosition.y - (bottom ? (fixedPosition.y > windowHeight / 2 ? menu?.clientHeight : 0) : 0)}px;`
 				: menu?.getBoundingClientRect()?.left > windowWidth / 2
-				? 'right: 0;'
-				: 'left: 0;'}
+				? `right: 0;${bottom ? 'bottom: 40px;' : ''}`
+				: `left: 0;${bottom ? 'bottom: 40px;' : ''}`}
 			bind:this={menu}
 			in:fly|global={{ y: 5, duration: 100, delay: anchored ? 0 : 100 }}
 			out:fly|global={{ y: 5, duration: 100 }}

--- a/src/lib/components/ContextMenu/SelectableMenuItem.svelte
+++ b/src/lib/components/ContextMenu/SelectableMenuItem.svelte
@@ -1,0 +1,19 @@
+<script lang="ts">
+    import classNames from 'classnames';
+    import { Check } from "radix-icons-svelte";
+    import ContextMenuItem from "./ContextMenuItem.svelte";
+
+    export let selected = false;
+</script>
+
+<ContextMenuItem on:click>
+    <div class="flex items-center justify-between cursor-pointer">
+        <Check size={20} class={classNames('mr-4', {
+            'opacity-0': !selected,
+            'opacity-100': selected
+        })} />
+        <div class="flex items-center text-left w-32">
+            <slot />
+        </div>
+    </div>
+</ContextMenuItem>

--- a/src/lib/components/VideoPlayer/Slider.svelte
+++ b/src/lib/components/VideoPlayer/Slider.svelte
@@ -1,0 +1,39 @@
+<script lang="ts">
+    export let min = 0;
+    export let max = 100;
+    export let step = 1;
+    export let primaryValue = 0;
+    export let secondaryValue = 0;
+
+    let progressBarOffset = 0;
+</script>
+
+<div class="h-2 relative group">
+    <!-- 0.54 em is half the width of the input thumb size -->
+    <div class="h-full relative px-[0.54em]">
+        <div class="h-full bg-gray-300 rounded-full overflow-hidden relative">
+            <!-- Secondary progress -->
+            <div class="h-full bg-gray-400 absolute top-0" 
+                style="width: {secondaryValue / max * 100}%;">
+            </div>
+
+            <!-- Primary progress -->
+            <div class="h-full bg-amber-200 absolute top-0" 
+                style="width: {primaryValue / max * 100}%;"
+                bind:offsetWidth={progressBarOffset}>
+            </div>
+        </div>
+
+        <div class="absolute w-4 h-4 bg-amber-200 rounded-full transform mx-2 -translate-x-1/2 -translate-y-1/2 top-1/2 cursor-pointer
+                    drop-shadow-md group-hover:scale-125 group-hover:shadow-lg transition-transform duration-100"
+            style="left: {progressBarOffset}px;"
+        ></div>
+    </div>
+
+    <input
+        type="range"
+        class="w-full h-full absolute cursor-pointer opacity-0 transform -translate-y-2"
+        min={min} max={max} step={step} bind:value={primaryValue} on:mouseup on:mousedown
+        on:touchstart on:touchend
+    />
+</div>

--- a/src/lib/components/VideoPlayer/Slider.svelte
+++ b/src/lib/components/VideoPlayer/Slider.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
     export let min = 0;
     export let max = 100;
-    export let step = 1;
+    export let step = 0.01;
     export let primaryValue = 0;
     export let secondaryValue = 0;
 

--- a/src/lib/components/VideoPlayer/VideoPlayer.svelte
+++ b/src/lib/components/VideoPlayer/VideoPlayer.svelte
@@ -1,36 +1,110 @@
 <script lang="ts">
+	import { fade } from 'svelte/transition';
 	import {
 		getJellyfinItem,
 		getJellyfinPlaybackInfo,
 		reportJellyfinPlaybackProgress,
 		reportJellyfinPlaybackStarted,
-		reportJellyfinPlaybackStopped
+		reportJellyfinPlaybackStopped,
+		delteActiveEncoding
 	} from '$lib/apis/jellyfin/jellyfinApi';
+	import { getQualities } from '$lib/apis/jellyfin/qualities';
 	import getDeviceProfile from '$lib/apis/jellyfin/playback-profiles';
 	import classNames from 'classnames';
 	import Hls from 'hls.js';
-	import { Cross2 } from 'radix-icons-svelte';
-	import { onDestroy } from 'svelte';
+	import { Cross2, Play, Pause, EnterFullScreen, ExitFullScreen, 
+		SpeakerLoud, SpeakerModerate, SpeakerQuiet, SpeakerOff, Gear } from 'radix-icons-svelte';
+	import { onDestroy, onMount } from 'svelte';
 	import IconButton from '../IconButton.svelte';
 	import { playerState } from './VideoPlayer';
 	import { modalStack } from '../Modal/Modal';
 	import { JELLYFIN_BASE_URL } from '$lib/constants';
+	import { contextMenu } from '../ContextMenu/ContextMenu';
+	import Slider from './Slider.svelte'
+	import ContextMenu from '../ContextMenu/ContextMenu.svelte';
+	import SelectableMenuItem from '../ContextMenu/SelectableMenuItem.svelte';
 
 	export let modalId: symbol;
-
-	let uiVisible = true;
+	
+	let qualityContextMenuId = Symbol();
 
 	let video: HTMLVideoElement;
+	let videoWrapper: HTMLDivElement;
 	let mouseMovementTimeout: NodeJS.Timeout;
 	let stopCallback: () => void;
+	let deleteEncoding: () => void;
+	let reportProgress: () => void;
 	let progressInterval: NodeJS.Timeout;
 
-	const fetchPlaybackInfo = (itemId: string) =>
+	// These functions are different in every browser
+	let reqFullscreenFunc: ((elem : HTMLElement) => void) | undefined = undefined;
+	let exitFullscreen: (() => void) | undefined = undefined;
+	let fullscreenChangeEvent: string | undefined = undefined;
+	let getFullscreenElement: (() => HTMLElement) | undefined = undefined;
+
+	// Find the correct functions
+	let elem = document.createElement('div');
+	// @ts-ignore
+	if (elem.requestFullscreen) {
+		reqFullscreenFunc = (elem) => { elem.requestFullscreen(); };
+		fullscreenChangeEvent = 'fullscreenchange';
+		getFullscreenElement = () => <HTMLElement> document.fullscreenElement;
+		if (document.exitFullscreen) exitFullscreen = () => document.exitFullscreen();
+	// @ts-ignore
+	} else if (elem.webkitRequestFullscreen) {
+		// @ts-ignore
+		reqFullscreenFunc = (elem) => { elem.webkitRequestFullscreen(); };
+		fullscreenChangeEvent = 'webkitfullscreenchange';
+		// @ts-ignore
+		getFullscreenElement = () => <HTMLElement> document.webkitFullscreenElement;
+			// @ts-ignore
+		if (document.webkitExitFullscreen) exitFullscreen = () => document.webkitExitFullscreen();
+	// @ts-ignore
+	} else if (elem.msRequestFullscreen) {
+		// @ts-ignore
+		reqFullscreenFunc = (elem) => { elem.msRequestFullscreen(); }
+		fullscreenChangeEvent = 'MSFullscreenChange';
+		// @ts-ignore
+		getFullscreenElement = () => <HTMLElement> document.msFullscreenElement;
+		// @ts-ignore
+		if (document.msExitFullscreen) exitFullscreen = () => document.msExitFullscreen();
+	// @ts-ignore
+	} else if (elem.mozRequestFullScreen) {
+		// @ts-ignore
+		reqFullscreenFunc = (elem) => { elem.mozRequestFullScreen(); };
+		fullscreenChangeEvent = 'mozfullscreenchange';
+		// @ts-ignore
+		getFullscreenElement = () => <HTMLElement> document.mozFullScreenElement;
+		// @ts-ignore
+		if (document.mozCancelFullScreen) exitFullscreen = () => document.mozCancelFullScreen();
+	}
+
+	let paused : boolean;
+	let duration : number = 0;
+	let displayedTime : number = 0;
+	let bufferedTime : number = 0;
+
+	let seeking : boolean = false;
+	let playerStateBeforeSeek : boolean;
+
+	let fullscreen : boolean = false;
+	let volume : number = 1;
+	let mute : boolean = false;
+
+	let resolution : number = 1080;
+	let currentBitrate : number = 0;
+
+	let shouldCloseUi = false;
+	let uiVisible = true;
+	$: uiVisible = !shouldCloseUi || seeking || paused || $contextMenu === qualityContextMenuId
+
+	const fetchPlaybackInfo = (itemId: string, maxBitrate: number | undefined = undefined, starting : boolean = true) =>
 		getJellyfinItem(itemId).then((item) =>
 			getJellyfinPlaybackInfo(
 				itemId,
 				getDeviceProfile(),
-				item?.UserData?.PlaybackPositionTicks || 0
+				item?.UserData?.PlaybackPositionTicks || Math.floor(displayedTime * 10_000_000),
+				maxBitrate || getQualities(item?.Height || 1080)[0].maxBitrate
 			).then(async (playbackInfo) => {
 				if (!playbackInfo) return;
 				const { playbackUri, playSessionId: sessionId, mediaSourceId, directPlay } = playbackInfo;
@@ -57,26 +131,77 @@
 					video.src = JELLYFIN_BASE_URL + playbackUri;
 				}
 
+				resolution = item?.Height || 1080;
+				currentBitrate = maxBitrate || getQualities(resolution)[0].maxBitrate;
+
 				if (item?.UserData?.PlaybackPositionTicks) {
 					video.currentTime = item?.UserData?.PlaybackPositionTicks / 10_000_000;
 				}
 
-				video.play().then(() => video.requestFullscreen());
-				if (mediaSourceId) await reportJellyfinPlaybackStarted(itemId, sessionId, mediaSourceId);
-				progressInterval = setInterval(() => {
-					video && video.readyState === 4 && video?.currentTime > 0 && sessionId && itemId;
-					reportJellyfinPlaybackProgress(
+				// We should not requestFullscreen automatically, as it's not what
+				// the user expects. Moreover, most browsers will deny the request
+				// if the video takes a while to load.
+				// video.play().then(() => videoWrapper.requestFullscreen());
+
+				// A start report should only be sent when the video starts playing,
+				// not every time a playback info request is made
+				if (mediaSourceId && starting) await reportJellyfinPlaybackStarted(itemId, sessionId, mediaSourceId);
+
+				reportProgress = async () => {
+					await reportJellyfinPlaybackProgress(
 						itemId,
 						sessionId,
 						video?.paused == true,
 						video?.currentTime * 10_000_000
 					);
+				}
+
+				if (progressInterval) clearInterval(progressInterval);
+				progressInterval = setInterval(() => {
+					video && video.readyState === 4 && video?.currentTime > 0 && sessionId && itemId;
+					reportProgress();
 				}, 5000);
+
+				deleteEncoding = () => {
+					delteActiveEncoding(sessionId);
+				}
+
 				stopCallback = () => {
 					reportJellyfinPlaybackStopped(itemId, sessionId, video?.currentTime * 10_000_000);
+					deleteEncoding();
 				};
 			})
 		);
+
+	function onSeekStart() {
+		if (seeking) return;
+	
+		playerStateBeforeSeek = paused;
+		seeking = true;
+		paused = true;
+	}
+
+	function onSeekEnd() {
+		if (!seeking) return;
+
+		paused = playerStateBeforeSeek;
+		seeking = false;
+
+		video.currentTime = displayedTime;
+	}
+
+	function handleBuffer() {
+		let timeRanges = video.buffered;
+		// Find the first one whose end time is after the current time 
+		// (the time ranges given by the browser are normalized, which means
+		// that they are sorted and non-overlapping)
+		for (let i = 0; i < timeRanges.length; i++) {
+			if (timeRanges.end(i) > video.currentTime) {
+				bufferedTime = timeRanges.end(i);
+				break;
+			}
+		}
+	}
 
 	function handleClose() {
 		playerState.close();
@@ -86,38 +211,191 @@
 		modalStack.close(modalId);
 	}
 
-	function handleMouseMove() {
-		// uiVisible = true;
-		// clearTimeout(mouseMovementTimeout);
-		// mouseMovementTimeout = setTimeout(() => {
-		// 	uiVisible = false;
-		// }, 2000);
+	function handleUserInteraction(touch : boolean = false) {
+		if (touch) shouldCloseUi = !shouldCloseUi;
+		else shouldCloseUi = false;
+
+		if (uiVisible) {
+			clearTimeout(mouseMovementTimeout);
+			mouseMovementTimeout = setTimeout(() => {
+				shouldCloseUi = true;
+			}, 3000);
+		} else {
+			if (mouseMovementTimeout) clearTimeout(mouseMovementTimeout);
+		}
 	}
 
-	onDestroy(() => clearInterval(progressInterval));
+	function handleQualityTogglVisibility() {
+		if ($contextMenu === qualityContextMenuId) contextMenu.hide();
+		else contextMenu.show(qualityContextMenuId);
+	}
+
+	async function handleSelectQuality(bitrate : number) {
+		if (!$playerState.jellyfinId || !video || seeking) return;
+		if (bitrate === currentBitrate) return;
+
+		currentBitrate = bitrate;
+		video.pause();
+		let timeBeforeLoad = video.currentTime;
+		let stateBeforeLoad = paused;
+		await reportProgress?.();
+		await deleteEncoding?.();
+		await fetchPlaybackInfo?.($playerState.jellyfinId, bitrate, false);
+		video.currentTime = timeBeforeLoad;
+		paused = stateBeforeLoad;
+	}
+
+	function secondsToTime(seconds : number, forceHours = false) {
+		if (isNaN(seconds)) return '00:00';
+
+		const hours = Math.floor(seconds / 3600);
+		const minutes = Math.floor((seconds - hours * 3600) / 60);
+		const secondsLeft = Math.floor(seconds - hours * 3600 - minutes * 60);
+		
+		let str = '';
+		if (hours > 0 || forceHours) str += `${hours}:`;
+
+		if (minutes >= 10) str += `${minutes}:`;
+		else str += `0${minutes}:`;
+
+		if (secondsLeft >= 10) str += `${secondsLeft}`;
+		else str += `0${secondsLeft}`;
+
+		return str;
+	}
+
+	onMount(() => {
+		// Workaround because the paused state does not sync
+		// with the video element until a change is made
+		paused = false;
+	});
+
+	onDestroy(() => {
+		clearInterval(progressInterval);
+		if (fullscreen) exitFullscreen?.();
+	});
 
 	$: {
 		if (video && $playerState.jellyfinId) {
 			if (video.src === '') fetchPlaybackInfo($playerState.jellyfinId);
 		}
 	}
+
+	$: {
+		if (fullscreen && !getFullscreenElement?.()) {
+			if (reqFullscreenFunc) reqFullscreenFunc(videoWrapper);
+		} else if (getFullscreenElement?.()) {
+			if (exitFullscreen) exitFullscreen();
+		}
+	}
+
+	// We add a listener to the fullscreen change event to update the fullscreen variable
+	// since it can be changed by the user by other means than the button
+	if (fullscreenChangeEvent) {
+		document.addEventListener(fullscreenChangeEvent, () => {
+			fullscreen = !!getFullscreenElement?.();
+		});
+	}
 </script>
 
 <!-- svelte-ignore a11y-no-static-element-interactions -->
 <div
-	class="bg-black w-screen h-screen relative flex items-center justify-center"
-	on:mousemove={handleMouseMove}
+	class={classNames("bg-black w-screen h-screen relative flex items-center justify-center", {
+		'cursor-none': !uiVisible
+	})}
 >
-	<!-- svelte-ignore a11y-media-has-caption -->
-	<video controls bind:this={video} class="sm:w-full sm:h-full" />
-	<div
-		class={classNames('absolute top-4 right-8 transition-opacity z-50', {
-			'opacity-0': !uiVisible,
-			'opacity-100': uiVisible
-		})}
-	>
-		<IconButton on:click={handleClose}>
-			<Cross2 size={25} />
-		</IconButton>
+	<div class="bg-black w-screen h-screen flex items-center justify-center" bind:this={videoWrapper}
+	on:mousemove={() => handleUserInteraction(false)} on:touchend|preventDefault={() => handleUserInteraction(true)}>
+		<!-- svelte-ignore a11y-media-has-caption -->
+		<video bind:this={video} bind:paused bind:duration on:timeupdate={() => displayedTime = (!seeking) ? video.currentTime : displayedTime}
+			   on:loadeddata={() => handleBuffer()} on:progress={() => handleBuffer()} on:play={() => {
+				if (seeking) video?.pause();
+			   }}
+			   bind:volume bind:muted={mute} class="sm:w-full sm:h-full" />
+
+		{#if uiVisible}
+			<!-- Video controls -->
+			<div class="absolute bottom-0 w-screen bg-gradient-to-t from-black/[.8] via-60% via-black-opacity-80 to-transparent" 
+			on:touchend|stopPropagation transition:fade={{duration: 100}}>
+				<div class="flex flex-col items-center space-y-4 p-5 w-full">
+					<div class = "flex items-center space-x-4 w-full">
+						<span class="whitespace-nowrap tabular-nums">{secondsToTime(displayedTime, duration > 3600)}</span>
+						<div class="flex-grow">
+							<Slider bind:primaryValue={displayedTime}
+									secondaryValue={bufferedTime}
+									max={duration}
+									on:mousedown={onSeekStart}
+									on:mouseup={onSeekEnd}
+									on:touchstart={onSeekStart}
+									on:touchend={onSeekEnd}/>
+						</div>
+						<span class="whitespace-nowrap tabular-nums">{secondsToTime(duration)}</span>
+					</div>
+
+					<div class="flex items-center justify-between mb-2 w-full">
+						<IconButton on:click={() => paused = !paused}>
+							{#if (!seeking && paused) || (seeking && playerStateBeforeSeek)}
+								<Play size={25} />
+							{:else}
+								<Pause size={25} />
+							{/if}
+						</IconButton>
+
+						<div class="flex items-center space-x-3">
+							<div class="relative">
+								<ContextMenu heading="Quality" position="absolute" bottom={true} id={qualityContextMenuId}>
+									<svelte:fragment slot="menu">
+										{#each getQualities(resolution) as quality}
+											<SelectableMenuItem 
+												selected={quality.maxBitrate === currentBitrate}
+												on:click={() => handleSelectQuality(quality.maxBitrate)}>
+												{quality.name}
+											</SelectableMenuItem>
+										{/each}
+									</svelte:fragment>
+									<IconButton on:click={handleQualityTogglVisibility}>
+										<Gear size={25} />
+									</IconButton>
+								</ContextMenu>
+							</div>
+
+							<IconButton on:click={() => {mute = !mute;}}>
+								{#if volume == 0 || mute}
+									<SpeakerOff size={25} />
+								{:else if volume < 0.25}
+									<SpeakerQuiet size={25} />
+								{:else if volume < 0.90}
+									<SpeakerModerate size={25} />
+								{:else}
+									<SpeakerLoud size={25} />
+								{/if}
+							</IconButton>
+
+							<div class="w-32">
+								<Slider bind:primaryValue={volume} secondaryValue={0} max={1} step={0.01} />
+							</div>
+
+							{#if reqFullscreenFunc}
+								<IconButton on:click={() => fullscreen = !fullscreen}>
+									{#if fullscreen}
+										<ExitFullScreen size={25} />
+									{:else if !fullscreen && exitFullscreen}
+										<EnterFullScreen size={25} />
+									{/if}
+								</IconButton>
+							{/if}
+						</div>
+					</div>
+				</div>
+			</div>
+		{/if}
 	</div>
+
+	{#if uiVisible}
+		<div class='absolute top-4 right-8 z-50' transition:fade={{duration: 100}}>
+			<IconButton on:click={handleClose}>
+				<Cross2 size={25} />
+			</IconButton>
+		</div>
+	{/if}
 </div>


### PR DESCRIPTION
This PR replaces the browser default video controls with custom ones, that are closer to the theme of the app, as well as allow us to personalise them much more in the future.

It also provides a quality selector, that changes the maximum bitrate of the streaming requested to Jellyfin. It's important to mention that the actual resolution written may not match what is actually playing, as the server decides the best resolution according to the specified bitrate (jellyfin does the same).

This PR has been tested both in Firefox 116.0.2 on Windows 11 as well as Safari on iPadOS 16.3, where it works flawlessly, as far as I have seen using the app. ~~It does NOT work on iPhone, since the stream does not play, probably because iOS (not iPadOS) does not support Media Source Extensions, but just raw Apple HLS, but the buttons and behavior of the things that can be tested seems to be fine~~ (it was fixed). Any further testing is highly appreciated.

Any suggestions or changes are highly appreciated and I will be more than happy on fixing any issues or improving the way I coded this.

Closes #17 