### PR TITLE
feat: Add manual instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,9 +26,27 @@ For a list of planned features & known bugs, see [Reiverr Taskboard](https://git
 
 # Installation
 
-The easiest and the recommended way to insstall Reiverr is via docker-compose. Make sure to update the api keys and base URLs to match your setup.
+The easiest and the recommended way to install Reiverr is via Docker. Make sure to update the api keys and base URLs to match your setup.
 
 Radarr & Sonarr API keys can be found under Settings > General in their respective web UIs. Jellyfin API key is located under Administration > Dashboard > Advanced > API Keys in the Jellyfin Web UI.
+
+### Docker CLI
+
+```sh
+docker run \
+  --name reiverr \
+  --restart unless-stopped \
+  -p 9494:9494 \
+  -e PUBLIC_RADARR_API_KEY=yourapikeyhere \
+  -e PUBLIC_RADARR_BASE_URL=http://127.0.0.1:7878 \
+  -e PUBLIC_SONARR_API_KEY=yourapikeyhere \
+  -e PUBLIC_SONARR_BASE_URL=http://127.0.0.1:8989 \
+  -e PUBLIC_JELLYFIN_API_KEY=yourapikeyhere \
+  -e PUBLIC_JELLYFIN_BASE_URL=http://127.0.0.1:8096 \
+  ghcr.io/aleksilassila/reiverr:latest
+```
+
+### Docker compose
 
 ```yaml
 version: '3.8'
@@ -50,6 +68,24 @@ services:
       PUBLIC_JELLYFIN_BASE_URL: http://127.0.0.1:8096
     restart: unless-stopped
 ```
+
+### Manual
+
+1. Requirements:
+    - Node v18.14.0 or high
+    - NPM v9.3.1 or high
+1. Clone from **master** or download the [latest source](https://github.com/aleksilassila/reiverr/releases)
+1. Copy the `.env.example` to `.env` and replace the values
+1. Build the app:
+    ```sh
+    npm ci --ignore-scripts
+    npm run build
+    npm ci --ignore-scripts --omit=dev # optional
+    ```
+1. Start the app:
+    ```sh
+    npm run deploy
+    ```
 
 ### Reiverr will be accessible via port 9494 by default.
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Radarr & Sonarr API keys can be found under Settings > General in their respecti
 ### Docker CLI
 
 ```sh
-docker run \
+docker run -it --init \
   --name reiverr \
   --restart unless-stopped \
   -p 9494:9494 \

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
 			"dependencies": {
 				"@jellyfin/sdk": "^0.7.0",
 				"axios": "^1.4.0",
+				"dotenv": "16.3.1",
 				"hls.js": "^1.4.6",
 				"openapi-fetch": "^0.2.1",
 				"radix-icons-svelte": "^1.2.1",
@@ -2298,6 +2299,17 @@
 			},
 			"engines": {
 				"node": ">=6.0.0"
+			}
+		},
+		"node_modules/dotenv": {
+			"version": "16.3.1",
+			"resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.3.1.tgz",
+			"integrity": "sha512-IPzF4w4/Rd94bA9imS68tZBaYyBWSCE47V1RGuMrB94iyTOIEwRmVL2x/4An+6mETpLrKJ5hQkB8W4kFAadeIQ==",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/motdotla/dotenv?sponsor=1"
 			}
 		},
 		"node_modules/electron-to-chromium": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
 		"dev": "vite dev --host",
 		"build": "vite build",
 		"preview": "vite preview",
-		"deploy": "PORT=9494 node build/",
+		"deploy": "PORT=9494 NODE_ENV=production node -r dotenv/config build/",
 		"test": "playwright test",
 		"check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
 		"check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
@@ -50,6 +50,7 @@
 	"dependencies": {
 		"@jellyfin/sdk": "^0.7.0",
 		"axios": "^1.4.0",
+		"dotenv": "16.3.1",
 		"hls.js": "^1.4.6",
 		"openapi-fetch": "^0.2.1",
 		"radix-icons-svelte": "^1.2.1",


### PR DESCRIPTION
Svelte docs suggest us to use `dotenv` dependency to load from the `.env` file https://kit.svelte.dev/docs/adapter-node#environment-variables

I followed the steps similar to the Dockerfile, I just mention the `v18.14.0` because it is the first version to comes with NPM 9 (which uses the lock-file 3) so that may keep things more consistent and error prone.

I also splitted the Docker instructions in two, as I think not everyone needs compose.

This may closes #45 but yet people needs to built their own daemon... Maybe another MR I can add some daemon examples like Systemd and OpenRC