### PR TITLE
[PERF] Progressive Rendering

### DIFF
--- a/src/lib/apis/tmdb/tmdbApi.ts
+++ b/src/lib/apis/tmdb/tmdbApi.ts
@@ -135,10 +135,8 @@ export const getTmdbSeriesSeason = async (
 		}
 	}).then((res) => res.data);
 
-export const getTmdbSeriesSeasons = async (tmdbId: number, seasons: number) =>
-	Promise.all([...Array(seasons).keys()].map((i) => getTmdbSeriesSeason(tmdbId, i + 1))).then(
-		(r) => r.filter((s) => s) as TmdbSeason[]
-	);
+export const getTmdbSeriesSeasons = (tmdbId: number, seasons: number) =>
+	[...Array(seasons).keys()].map((i) => getTmdbSeriesSeason(tmdbId, i + 1));
 
 export const getTmdbSeriesImages = async (tmdbId: number) =>
 	TmdbApiOpen.get('/3/tv/{series_id}/images', {

--- a/src/lib/components/TitleShowcase/TitleShowcaseBackground.svelte
+++ b/src/lib/components/TitleShowcase/TitleShowcaseBackground.svelte
@@ -11,9 +11,7 @@
 	const ANIMATION_DURATION = $settings.animationDuration;
 
 	export let tmdbId: number;
-
-	export let trailerId: string | undefined = undefined;
-
+	export let lazyTrailerId: Promise<string | undefined>;
 	export let backdropUri: string;
 
 	let scrollY: number;
@@ -22,6 +20,9 @@
 	let hoverTrailer = false;
 	export let UIVisible = true;
 	$: UIVisible = !(hoverTrailer && trailerVisible);
+
+	let trailerId: string | undefined = undefined;
+	lazyTrailerId.then((v) => (trailerId = v));
 
 	let trailerShowTimeout: NodeJS.Timeout | undefined = undefined;
 	$: {
@@ -64,7 +65,7 @@
 
 <svelte:window bind:scrollY on:scroll={handleWindowScroll} />
 
-{#if !trailerVisible}
+{#if !trailerVisible || !trailerId}
 	{#key tmdbId}
 		<div
 			style={"background-image: url('" + TMDB_IMAGES_ORIGINAL + backdropUri + "');"}

--- a/src/lib/components/TitleShowcase/TitleShowcaseVisuals.svelte
+++ b/src/lib/components/TitleShowcase/TitleShowcaseVisuals.svelte
@@ -8,6 +8,7 @@
 	import type { TitleType } from '$lib/types';
 	import { openTitleModal } from '$lib/stores/modal.store';
 	import { settings } from '$lib/stores/settings.store';
+	import { TMDB_MOVIE_GENRES } from '$lib/apis/tmdb/tmdbApi';
 
 	const ANIMATION_DURATION = $settings.animationDuration;
 
@@ -15,8 +16,8 @@
 	export let type: TitleType;
 
 	export let title: string;
-	export let genres: string[];
-	export let runtime: number;
+	export let genreIds: number[];
+	export let lazyRuntime: Promise<number>;
 	export let releaseDate: Date;
 	export let tmdbRating: number;
 
@@ -24,7 +25,14 @@
 
 	export let hideUI = false;
 
+	let runtime = 0;
+	let loadingAdditionalDetails = true;
+	lazyRuntime.then((rn) => (runtime = rn)).finally(() => (loadingAdditionalDetails = false));
+
 	$: tmdbUrl = `https://www.themoviedb.org/${type}/${tmdbId}`;
+	$: genres = genreIds
+		.map((gId) => TMDB_MOVIE_GENRES.find((g) => g.id === gId)?.name)
+		.filter<string>((g): g is string => typeof g === 'string');
 
 	function handleOpenTitle() {
 		openTitleModal({ type, id: tmdbId, provider: 'tmdb' });
@@ -60,7 +68,7 @@
 			>
 				<p class="flex-shrink-0">{releaseDate.getFullYear()}</p>
 				<DotFilled />
-				<p class="flex-shrink-0">{formatMinutesToTime(runtime)}</p>
+				<p class="flex-shrink-0">{loadingAdditionalDetails ? 'LOADING' : formatMinutesToTime(runtime)}</p>
 				<DotFilled />
 				<p class="flex-shrink-0"><a href={tmdbUrl}>{tmdbRating.toFixed(1)} TMDB</a></p>
 			</div>

--- a/src/lib/components/TitleShowcase/TitleShowcasesContainer.svelte
+++ b/src/lib/components/TitleShowcase/TitleShowcasesContainer.svelte
@@ -65,11 +65,49 @@
 		}
 	});
 
-	const tmdbPopularMoviesPromise = getTmdbPopularMovies()
-		.then((movies) => Promise.all(movies.map((movie) => getTmdbMovie(movie.id || 0))))
-		.then((movies) => movies.filter((m) => !!m).slice(0, 10));
+	let popularMovies: (
+		| {
+				movie: Awaited<ReturnType<typeof getTmdbPopularMovies>>[0];
+				lazyRuntime: Promise<number>;
+				lazyTrailerId: Promise<string | undefined>;
+		  }
+	)[] = [];
+
+	/**
+	 * Here we load a list of popular movies:
+	 *   * runtime & video data is not available as part of the initial request
+	 *   * If an additional detail request fails, we unload the movie from the showcase
+	 */
+	const tmdbPopularMoviesPromise = getTmdbPopularMovies().then(
+		(movies) =>
+			(popularMovies = movies.map((movie) => {
+				const movieDetails = getTmdbMovie(movie.id || 0);
+				const movieDetailsPromise = movieDetails.then((fullMovie) => ({
+					runtime: fullMovie?.runtime || 0,
+					trailerId: fullMovie?.videos?.results?.find(
+						(v) => v.site === 'YouTube' && v.type === 'Trailer'
+					)?.key
+				}));
+
+				movieDetails.catch(() => unloadMovie());
+				movieDetails.then((md) => !md && unloadMovie());
+				const unloadMovie = () => {
+					const idx = popularMovies.findIndex((m) => m.movie === movie);
+					popularMovies.splice(idx, 1);
+					popularMovies = popularMovies;
+				};
+
+				return {
+					movie,
+					lazyRuntime: movieDetailsPromise.then((fm) => fm.runtime),
+					lazyTrailerId: movieDetailsPromise.then((fm) => fm.trailerId)
+				};
+			}))
+	);
 
 	let showcaseIndex = 0;
+	$: clampedPopularMovies = popularMovies.slice(0, 10);
+	$: visibleShowcaseMovie = clampedPopularMovies[showcaseIndex];
 
 	async function onNext() {
 		showcaseIndex = (showcaseIndex + 1) % (await tmdbPopularMoviesPromise).length;
@@ -105,16 +143,16 @@
 			PADDING
 		)}
 	>
-		{#await tmdbPopularMoviesPromise then movies}
-			{@const movie = movies[showcaseIndex]}
+		{#if visibleShowcaseMovie}
+			{@const { movie, lazyRuntime, lazyTrailerId } = visibleShowcaseMovie}
 
 			{#key movie?.id}
 				<TitleShowcaseVisuals
 					tmdbId={movie?.id || 0}
 					type="movie"
 					title={movie?.title || ''}
-					genres={movie?.genres?.map((g) => g.name || '') || []}
-					runtime={movie?.runtime || 0}
+					genreIds={movie.genre_ids || []}
+					{lazyRuntime}
 					releaseDate={new Date(movie?.release_date || Date.now())}
 					tmdbRating={movie?.vote_average || 0}
 					posterUri={movie?.poster_path || ''}
@@ -124,7 +162,13 @@
 			<div
 				class="md:relative self-stretch flex justify-center items-end row-start-2 row-span-1 col-start-1 col-span-2 md:row-start-1 md:row-span-2 md:col-start-2 md:col-span-2"
 			>
-				<PageDots index={showcaseIndex} length={movies.length} {onJump} {onPrevious} {onNext} />
+				<PageDots
+					index={showcaseIndex}
+					length={clampedPopularMovies.length}
+					{onJump}
+					{onPrevious}
+					{onNext}
+				/>
 				{#if !hideUI}
 					<div class="absolute top-1/2 right-0 z-10">
 						<IconButton on:click={onNext}>
@@ -133,13 +177,15 @@
 					</div>
 				{/if}
 			</div>
-			<TitleShowcase
-				tmdbId={movie?.id || 0}
-				trailerId={movie?.videos?.results?.find((v) => v.site === 'YouTube' && v.type === 'Trailer')
-					?.key}
-				backdropUri={movie?.backdrop_path || ''}
-			/>
-		{/await}
+
+			{#key movie?.id}
+				<TitleShowcase
+					tmdbId={movie?.id || 0}
+					{lazyTrailerId}
+					backdropUri={movie?.backdrop_path || ''}
+				/>
+			{/key}
+		{/if}
 	</div>
 	<div
 		class={classNames('z-[1] transition-opacity', {


### PR DESCRIPTION
Forgive me this is my first time using Svelte 😅 

# TL;DR
The homepage, movie page & series page have been minimally refactored to support faster load times. 

By refactoring these API response promise chains we can load pieces of the UI progressively rather than waiting for all parts to finish.

# Context
Currently the Reiverr app can be sluggish when navigating to new content, especially TV series with lots of seasons.

This PR seeks to improve the perceived performance of the overall app by progressively rendering various page sections.

# Render Comparison


<table>
  <tr>
    <th colspan="2">Homepage</th>
  </tr>
  <tr>
    <th>Production</th>
    <th>Progressively Rendered</th>
  </tr>
  <tr>
    <td><video src="https://github.com/aleksilassila/reiverr/assets/23309167/0fe026c2-909f-4281-81e0-a322bf1ccd5a" /></td>
    <td>(*) <video src="https://github.com/aleksilassila/reiverr/assets/23309167/6040040b-e192-46e1-9c42-ecc64a65c8b6" /></td>
  </tr>
  <tr>
    <td colspan="2">
      * the showcase trailer being sped up must have been a strange buffering thing when i started screen recording
    </td>
  </tr>
  <tr>
    <th colspan="2">TV Series</th>
  </tr>
  <tr>
    <th>Production</th>
    <th>Progressively Rendered</th>
  </tr>
  <tr>
    <td><video src="https://github.com/aleksilassila/reiverr/assets/23309167/db809935-1f41-4d9d-81a2-3b9e56bcdced" /></td>
    <td>(*) <video src="https://github.com/aleksilassila/reiverr/assets/23309167/ff014fe8-53a2-4724-a318-f422d4391517" /></td>
  </tr>
  <tr>
    <td colspan="2">
      * the genres rendering in after a delay on the showcase has been fixed
    </td>
  </tr>
<tr>
    <th colspan="2">Movies</th>
  </tr>
  <tr>
    <th>Production</th>
    <th>Progressively Rendered</th>
  </tr>
  <tr>
    <td><video src="https://github.com/aleksilassila/reiverr/assets/23309167/94e96bba-f4db-4d3a-8e85-def0c2e47021" /></td>
    <td><video src="https://github.com/aleksilassila/reiverr/assets/23309167/07793be4-e652-4e18-9095-7422a4b444d7" /></td>
  </tr>
</table>


# Change Summary
  * Refactored `getTmdbSeriesSeasons` to unwrap each season API response promise
  * Refactored the `TitleShowcaseContainer` to display the showcase as soon as the `getTmdbPopularMovies` response is resolved, opposed to awaiting n+1 movie-detail request.
  * Introduced "lazy" props to `TitleShowcaseVisuals` as a hacky solution for handling data which comes from the `movie-detail` API request  and is not immediately available.
  * Isolated the promise chains for fetching movie details with those associated with secondary data such as recommendations, cast, etc.
  * Refactored the series page implicitly into three conceptual state blocks: `seriesData`, `episodesData`, `recommendationsData`. `seriesData` is the only render-blocking block now.

# Implementation
A rough explanation of the changes is as follows.

### Homepage
When loading the homepage we show a list of 10 popular movies. These movies are returned from a single API request. For each movie we make an additional request to collect additional data(trailer, runtime minutes, etc).

Now we present the showcase to the user immediately after the first request is resolved, and display runtime / trailer once the subsequent request is resolved. This has a relatively significant impact on render times.

### Movies
In production when viewing a movie the whole page is blocked from rendering until all associated requests have been resolved. By isolating the movie details request from requests for recommendations, cast, similar etc we can begin rendering much earlier.

### Series
Similarly to movies, the series page blocks rendering until all associated requests have finished. Notable here as some series have upwards of 30 seasons, which is 30 requests to await. Series data, Episode data and recommendation data are now rendered concurrently.

# Future Improvements
Latency could be reduced further by using an internal API to implement a short-lived cache on TMDB requests, given the output of these discovery endpoints seems to be stable within at least a 24 hour period.

This would also significantly reduce overall API utilisation.

> The API rate limits sit somewhere in the 50 requests per second range.

paraphrased from the [docs](https://arc.net/l/quote/kxvqnzpa)

As a concrete example, loading the simpsons series page currently sends at least 35 individual requests on page load. IIUC this token is shared application-wide meaning 10 people loading the simpsons page, on their locally installed instance would mean 350 concurrent requests tagged against the API token.