### PR TITLE
update playwright version, add basic tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
 			"devDependencies": {
 				"@fontsource/fira-mono": "^4.5.10",
 				"@neoconfetti/svelte": "^1.0.0",
-				"@playwright/test": "^1.28.1",
+				"@playwright/test": "^1.41.2",
 				"@sveltejs/adapter-auto": "^2.0.0",
 				"@sveltejs/adapter-node": "^1.3.1",
 				"@sveltejs/kit": "^1.5.0",
@@ -1197,22 +1197,18 @@
 			}
 		},
 		"node_modules/@playwright/test": {
-			"version": "1.35.0",
-			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.35.0.tgz",
-			"integrity": "sha512-6qXdd5edCBynOwsz1YcNfgX8tNWeuS9fxy5o59D0rvHXxRtjXRebB4gE4vFVfEMXl/z8zTnAzfOs7aQDEs8G4Q==",
+			"version": "1.41.2",
+			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.41.2.tgz",
+			"integrity": "sha512-qQB9h7KbibJzrDpkXkYvsmiDJK14FULCCZgEcoe2AvFAS64oCirWTwzTlAYEbKaRxWs5TFesE1Na6izMv3HfGg==",
 			"dev": true,
 			"dependencies": {
-				"@types/node": "*",
-				"playwright-core": "1.35.0"
+				"playwright": "1.41.2"
 			},
 			"bin": {
 				"playwright": "cli.js"
 			},
 			"engines": {
 				"node": ">=16"
-			},
-			"optionalDependencies": {
-				"fsevents": "2.3.2"
 			}
 		},
 		"node_modules/@polka/url": {
@@ -4265,6 +4261,20 @@
 			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
 			"integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="
 		},
+		"node_modules/fsevents": {
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+			"integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+			"dev": true,
+			"hasInstallScript": true,
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+			}
+		},
 		"node_modules/function-bind": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
@@ -5965,10 +5975,28 @@
 				"node": ">= 6"
 			}
 		},
+		"node_modules/playwright": {
+			"version": "1.41.2",
+			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.41.2.tgz",
+			"integrity": "sha512-v0bOa6H2GJChDL8pAeLa/LZC4feoAMbSQm1/jF/ySsWWoaNItvrMP7GEkvEEFyCTUYKMxjQKaTSg5up7nR6/8A==",
+			"dev": true,
+			"dependencies": {
+				"playwright-core": "1.41.2"
+			},
+			"bin": {
+				"playwright": "cli.js"
+			},
+			"engines": {
+				"node": ">=16"
+			},
+			"optionalDependencies": {
+				"fsevents": "2.3.2"
+			}
+		},
 		"node_modules/playwright-core": {
-			"version": "1.35.0",
-			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.35.0.tgz",
-			"integrity": "sha512-muMXyPmIx/2DPrCHOD1H1ePT01o7OdKxKj2ebmCAYvqhUy+Y1bpal7B0rdoxros7YrXI294JT/DWw2LqyiqTPA==",
+			"version": "1.41.2",
+			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.41.2.tgz",
+			"integrity": "sha512-VaTvwCA4Y8kxEe+kfm2+uUUw5Lubf38RxF7FpBxLPmGe5sdNkSg5e3ChEigaGrX7qdqT3pt2m/98LiyvU2x6CA==",
 			"dev": true,
 			"bin": {
 				"playwright-core": "cli.js"

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
 	"devDependencies": {
 		"@fontsource/fira-mono": "^4.5.10",
 		"@neoconfetti/svelte": "^1.0.0",
-		"@playwright/test": "^1.28.1",
+		"@playwright/test": "^1.41.2",
 		"@sveltejs/adapter-auto": "^2.0.0",
 		"@sveltejs/adapter-node": "^1.3.1",
 		"@sveltejs/kit": "^1.5.0",

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -5,4 +5,4 @@ export const TMDB_BACKDROP_SMALL = 'https://www.themoviedb.org/t/p/w780';
 export const TMDB_POSTER_SMALL = 'https://www.themoviedb.org/t/p/w342';
 export const TMDB_PROFILE_SMALL = 'https://www.themoviedb.org/t/p/w185';
 
-export const PLACEHOLDER_BACKDROP = '/plcaeholder.jpg';
+export const PLACEHOLDER_BACKDROP = '/placeholder.jpg';

--- a/tests/UI.spec.ts
+++ b/tests/UI.spec.ts
@@ -1,0 +1,122 @@
+//@ts-check
+import { expect, test } from '@playwright/test';
+import { readFileSync } from 'fs';
+import { fileURLToPath } from 'url';
+
+const file = fileURLToPath(new URL('../package.json', import.meta.url));
+const json = readFileSync(file, 'utf8');
+const pkg = JSON.parse(json);
+
+test.describe('UI Tests', () => {
+	test('Home page', async ({ page }) => {
+		await page.goto('/');
+		await expect(page.getByText('Home')).toBeVisible();
+		await page.getByText('Home').click();
+		await test.step('Check top bar links exist', async () => {
+			await expect(page.getByRole('link', {name: 'Reiverr', exact: true})).toBeVisible();
+			await expect(page.getByRole('link', {name: 'Reiverr', exact: true})).toHaveAttribute('href', '/')
+			await expect(page.getByRole('link', {name: 'Home', exact: true})).toBeVisible();
+			await expect(page.getByRole('link', {name: 'Home', exact: true})).toHaveAttribute('href', '/')
+			await expect(page.getByRole('link', {name: 'Library', exact: true})).toBeVisible();
+			await expect(page.getByRole('link', {name: 'Library', exact: true})).toHaveAttribute('href', '/library')
+			await expect(page.getByRole('link', {name: 'Sources', exact: true})).toBeVisible();
+			await expect(page.getByRole('link', {name: 'Sources', exact: true})).toHaveAttribute('href', '/sources')
+			await expect(page.getByRole('link', {name: 'Settings', exact: true})).toBeVisible();
+			await expect(page.getByRole('link', {name: 'Settings', exact: true})).toHaveAttribute('href', '/settings')
+		});
+
+		await test.step('Check Carousel sections exist', async () => {
+			await expect(page.getByText('Popular People', {exact: true})).toBeVisible();
+			await expect(page.getByText('Upcoming Movies', {exact: true})).toBeVisible();
+			await expect(page.getByText('Upcoming Series', {exact: true})).toBeVisible();
+			await expect(page.getByText('Genres', {exact: true})).toBeVisible();
+			await expect(page.getByText('New Digital Releases', {exact: true})).toBeVisible();
+			await expect(page.getByText('Streaming Now', {exact: true})).toBeVisible();
+			await expect(page.getByText('TV Networks', {exact: true})).toBeVisible();
+		});
+	});
+
+	test('Library', async ({ page }) => {
+		await page.goto('/library');
+		await expect(page.getByText('Latest Addition')).toBeVisible();
+		await expect(page.getByRole('button', {name: 'Available', exact: true})).toBeVisible();
+		await expect(page.getByRole('button', {name: 'Watched', exact: true})).toBeVisible();
+		await expect(page.getByRole('button', {name: 'Unavailable', exact: true})).toBeVisible();
+		await expect(page.getByRole('button', {name: 'Play', exact: true})).toBeVisible();
+		await expect(page.getByRole('button', {name: 'Details', exact: true})).toBeVisible();
+	});
+
+	test('Sources', async ({ page }) => {
+		await page.goto('/sources');
+		await expect(page.getByText('Movies Provider')).toBeVisible();
+		await expect(page.getByText('Radarr')).toBeVisible();
+		await expect(page.getByText('Shows Provider')).toBeVisible();
+		await expect(page.getByText('Sonarr')).toBeVisible();
+	});
+
+	test('Settings', async ({ page }) => {
+		await page.goto('/settings');
+
+		await test.step('Check top bar links exist', async () => {
+			await expect(page.getByRole('link', {name: 'Reiverr', exact: true})).toBeVisible();
+			await expect(page.getByRole('link', {name: 'Reiverr', exact: true})).toHaveAttribute('href', '/')
+			await expect(page.getByRole('link', {name: 'Home', exact: true})).toBeVisible();
+			await expect(page.getByRole('link', {name: 'Home', exact: true})).toHaveAttribute('href', '/')
+			await expect(page.getByRole('link', {name: 'Library', exact: true})).toBeVisible();
+			await expect(page.getByRole('link', {name: 'Library', exact: true})).toHaveAttribute('href', '/library')
+			await expect(page.getByRole('link', {name: 'Sources', exact: true})).toBeVisible();
+			await expect(page.getByRole('link', {name: 'Sources', exact: true})).toHaveAttribute('href', '/sources')
+			await expect(page.getByRole('link', {name: 'Settings', exact: true})).toBeVisible();
+			await expect(page.getByRole('link', {name: 'Settings', exact: true})).toHaveAttribute('href', '/settings')
+		});
+
+		await test.step('Check side buttons exist', async () => {
+			await expect(page.getByRole('button', {name: 'General', exact: true})).toBeVisible();
+			await expect(page.getByRole('button', {name: 'Integrations', exact: true})).toBeVisible();
+		});
+
+		await test.step('Check bottom bar links exist', async () => {
+			await expect(page.getByText(pkg.version)).toBeVisible();
+			await expect(page.getByRole('link', {name: 'Changelog', exact: true})).toBeVisible();
+			await expect(page.getByRole('link', {name: 'Changelog', exact: true})).toHaveAttribute('href', 'https://github.com/aleksilassila/reiverr/releases');
+			await expect(page.getByRole('link', {name: 'GitHub', exact: true})).toBeVisible();
+			await expect(page.getByRole('link', {name: 'GitHub', exact: true})).toHaveAttribute('href', 'https://github.com/aleksilassila/reiverr');
+		});
+		await test.step('Check User Interface section', async () => {
+			await expect(page.getByRole('heading', {name: 'User Interface'})).toBeVisible();
+			await expect(page.getByRole('heading', { name: 'Language', exact: true })).toBeVisible();
+			await expect(page.getByRole('combobox').first()).toBeVisible();
+			await expect(page.getByRole('button', {name: 'Save Changes'})).toHaveClass(/cursor-not-allowed/);
+			await page.getByRole('combobox').first().click()
+			await page.getByRole('combobox').first().selectOption('en')
+			await expect(page.getByRole('button', {name: 'Save Changes'})).toHaveClass(/cursor-not-allowed/);
+			await page.getByRole('combobox').first().click()
+			await page.getByRole('combobox').first().selectOption('de')
+			await expect(page.getByRole('button', {name: 'Save Changes'})).not.toHaveClass(/cursor-not-allowed/);
+			await page.getByRole('combobox').first().click()
+			await page.getByRole('combobox').first().selectOption('es')
+			await expect(page.getByRole('button', {name: 'Save Changes'})).not.toHaveClass(/cursor-not-allowed/);
+			await page.getByRole('combobox').first().click()
+			await page.getByRole('combobox').first().selectOption('fr')
+			await expect(page.getByRole('button', {name: 'Save Changes'})).not.toHaveClass(/cursor-not-allowed/);
+			await page.getByRole('combobox').first().click()
+			await page.getByRole('combobox').first().selectOption('it')
+			await expect(page.getByRole('button', {name: 'Save Changes'})).not.toHaveClass(/cursor-not-allowed/);
+			await page.getByRole('combobox').first().click()
+			await page.getByRole('combobox').first().selectOption('en')
+			await expect(page.getByRole('button', {name: 'Save Changes'})).toHaveClass(/cursor-not-allowed/);
+			await expect(page.locator('.w-11').first()).toBeEnabled();
+			await expect(page.getByRole('spinbutton')).toHaveValue('150')
+		});
+
+		await test.step('Check Discovery section', async () => {
+			await expect(page.getByRole('heading', {name: 'Discovery', exact: true})).toBeVisible();
+			await expect(page.getByRole('heading', { name: 'Region', exact: true })).toBeVisible();
+			await expect(page.getByRole('combobox').nth(1)).toBeVisible();
+			await expect(page.getByRole('heading', { name: 'Exclude library items from Discovery', exact: true })).toBeVisible();
+			await expect(page.locator('.w-11').nth(1)).toBeEnabled();
+			await expect(page.getByText('Filter results based on spoken language. Takes ISO 639-1 language codes separated with commas. Leave empty to disable.')).toBeVisible();
+			await expect(page.getByPlaceholder('en,fr,de')).toBeVisible();
+		});
+	});
+});

--- a/tests/test.ts
+++ b/tests/test.ts
@@ -1,6 +1,0 @@
-import { expect, test } from '@playwright/test';
-
-test('about page has expected h1', async ({ page }) => {
-	await page.goto('/about');
-	await expect(page.getByRole('heading', { name: 'About this app' })).toBeVisible();
-});


### PR DESCRIPTION
Bumped the playwright version (to match VSCode extension for testability purposes)
Also corrected path for the placeholder image in /library (it was throwing an error).

Added some basic UI tests for each of the 4 main pages:

1. Main (/)
2. Library (/library)
3. Sources (/sources)
4. Settings (/settings)

If these are satisfactory (or not), or if you want any specifics as to what each test or test step does, please let me know.

I can expand on them and make them more modular or if you have any specifics you would like added, please also let me know.

Cheers