### PR TITLE
Updated taskboard link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Content Playback Plugins
   - [Jellyfin plugin](backend/packages/jellyfin.plugin/README.md)
   - [Torrent-Stream plugin](backend/packages/torrent-stream.plugin/README.md) (requires Jackett)
 
-For a list of planned features & known bugs, see [Reiverr Taskboard](https://github.com/users/aleksilassila/projects/5).
+For a list of planned features & known bugs, see [Reiverr Taskboard](https://github.com/users/aleksilassila/projects/7).
 
 # Installation
 


### PR DESCRIPTION
Changed taskboard link in README from `Reiverr 1.0 Taskboard` to `Reiverr 2.0 Taskboard`