### PR TITLE
fix : jellyfin library

### DIFF
--- a/backend/packages/torrent-stream.plugin/src/lib/torrent-manager.ts
+++ b/backend/packages/torrent-stream.plugin/src/lib/torrent-manager.ts
@@ -5,7 +5,10 @@ import * as torrentStream from 'torrent-stream';
 class FileCache<T> {
   private cache: T;
 
-  constructor(private cacheFile: string, private defaultValue: T) {
+  constructor(
+    private cacheFile: string,
+    private defaultValue: T,
+  ) {
     this.cache = this.readStreamCache();
   }
 
@@ -118,6 +121,9 @@ class EngineCache {
               process.env.TORRENT_STREAM_DOWNLOADS ??
                 'torrent-stream-downloads',
             ),
+      });
+      engine.listen(6141, () => {
+        console.info('Torrent engine listening on port 6141');
       });
       engine.on('ready', () => {
         res(engine);

--- a/backend/src/users/media-sources/media-sources.service.ts
+++ b/backend/src/users/media-sources/media-sources.service.ts
@@ -100,10 +100,17 @@ export class MediaSourcesService {
 
       if (provider) {
         validationResponse = await provider.validateSettings({
-          settings: sourceDto.pluginSettings,
-        });
-        valid = validationResponse.isValid;
+        settings: sourceDto.pluginSettings,
+      });
+      valid = validationResponse.isValid;
+      if (
+        validationResponse.settings &&
+        Object.keys(validationResponse.settings).length > 0
+      ) {
         source.pluginSettings = validationResponse.settings;
+      } else {
+        source.pluginSettings = sourceDto.pluginSettings;
+      }
       } else {
         source.pluginSettings = sourceDto.pluginSettings;
       }

--- a/src/lib/pages/ManagePage/MediaSources.ManagePage.svelte
+++ b/src/lib/pages/ManagePage/MediaSources.ManagePage.svelte
@@ -17,9 +17,9 @@
 
 <Container on:enter={scrollIntoView({ vertical: 128 })}>
 	<div class="mb-8">
-		<h1 class="h3 mb-1">Media Soruces</h1>
+		<h1 class="h3 mb-1">Media Sources</h1>
 		<p class="body">
-			External media soruces allow reiverr to play content from different sources. Additional media
+			External media sources allow reiverr to play content from different sources. Additional media
 			sources can be added via external plugins.
 		</p>
 	</div>


### PR DESCRIPTION
The parameters entered in the Jellyfin library were not properly saved to the database, which caused the library to fail to load.